### PR TITLE
Updated navigation-compose

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -3,5 +3,5 @@ object Versions {
     const val composeVersion = "1.0.1"
     const val lifecycleVersion = "2.3.0"
     const val hiltVersion = "2.38.1"
-    const val navigationVersion = "2.4.0-alpha08"
+    const val navigationVersion = "2.4.0-alpha09"
 }

--- a/compiler/src/main/kotlin/Types.kt
+++ b/compiler/src/main/kotlin/Types.kt
@@ -8,11 +8,11 @@ import com.squareup.kotlinpoet.MemberName
 val NavGraphBuilder = ClassName.bestGuess("androidx.navigation.NavGraphBuilder")
 val NavType = ClassName.bestGuess("androidx.navigation.NavType")
 val NavDeepLink = ClassName.bestGuess("androidx.navigation.NavDeepLink")
-val NamedNavArgument = ClassName.bestGuess("androidx.navigation.compose.NamedNavArgument")
+val NamedNavArgument = ClassName.bestGuess("androidx.navigation.NamedNavArgument")
 val NavOptionsBuilder = ClassName.bestGuess("androidx.navigation.NavOptionsBuilder")
 val PopUpToBuilder = ClassName.bestGuess("androidx.navigation.PopUpToBuilder")
 
-val navArgument = MemberName("androidx.navigation.compose", "navArgument")
+val navArgument = MemberName("androidx.navigation", "navArgument")
 val navDeepLink = MemberName("androidx.navigation", "navDeepLink")
 // endregion
 


### PR DESCRIPTION
## Overview
- Updated navigation-compose version to 2.4.0-alpha09
  - https://developer.android.com/jetpack/androidx/releases/navigation?hl=en#2.4.0-alpha09
- Fixed import package.
  >The navArgument Kotlin DSL function is now part of navigation-common instead of navigation-compose. This will require updating imports to continue to use this function. 