### PR TITLE
Removed ui-tooling dependency from library

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -56,7 +56,6 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.lifecycleVersion}")
 
     implementation("androidx.compose.ui:ui:${Versions.composeVersion}")
-    implementation("androidx.compose.ui:ui-tooling:${Versions.composeVersion}")
     implementation("androidx.compose.foundation:foundation:${Versions.composeVersion}")
     implementation("androidx.navigation:navigation-compose:${Versions.navigationVersion}")
 


### PR DESCRIPTION
## Overview
- Removed ui-tooling dependency from library because it is not needed.
- ref: https://twitter.com/vinaygaba/status/1488561816179331074

