### PR TITLE
Changed to be able to pass Navigator's to ScreenNavController

### DIFF
--- a/library/src/main/kotlin/ScreenNavController.kt
+++ b/library/src/main/kotlin/ScreenNavController.kt
@@ -2,8 +2,10 @@ package jp.takuji31.compose.navigation.screen
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
+import androidx.navigation.Navigator
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,8 +33,10 @@ class ScreenNavController(val navController: NavHostController) {
 }
 
 @Composable
-fun rememberScreenNavController(): ScreenNavController {
-    val navController = rememberNavController()
+fun rememberScreenNavController(
+    vararg navigators: Navigator<out NavDestination>
+): ScreenNavController {
+    val navController = rememberNavController(*navigators)
     return remember(navController) {
         ScreenNavController(navController)
     }


### PR DESCRIPTION
## Overview
- I want to use this library in combination with [navigation-material](https://google.github.io/accompanist/navigation-material/ ).
- So, it possible to pass Navigator to NavController.  

```Example.kt
setContent {
    AppTheme {
        val bottomSheetNavigator = rememberBottomSheetNavigator()
        val navController = rememberScreenNavController(bottomSheetNavigator)  // Like this
        ModalBottomSheetLayout(bottomSheetNavigator) {
            ScreenNavHost(
                navController = navController,
                startScreen = ExampleScreen.Home(),
            ) {
                exampleScreenComposable() {
                    home {}
                }
                bottomSheet(route = ExampleScreenId.Sheet.route) {}
        }
    }
}
```