### PR TITLE
Fixed Compose dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,8 +77,13 @@ dependencies {
     implementation(libs.appcompat)
     implementation(libs.material)
 
-    implementation(libs.bundles.compose)
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.ui)
+    implementation(libs.compose.foundation)
+    implementation(libs.compose.material)
+    implementation(libs.compose.material.icons.extended)
     implementation(libs.activity.compose)
+    debugImplementation(libs.compose.ui.tooling)
 
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
@@ -105,7 +110,8 @@ dependencies {
     // NOTE: Current limitation this library doesn't work correctly in single-module with kapt.correctErrorTypes=true
     implementation(project(":navigation"))
 
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:${Versions.composeVersion}")
+    androidTestImplementation(platform(libs.compose.bom))
+    androidTestImplementation(libs.compose.ui.test)
     androidTestImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.test:runner:1.5.2")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 android-plugin = "7.4.2"
 navigation = "2.5.3"
-compose = "1.3.3"
 lifecycle = "2.5.1"
 hilt = "2.45"
 coroutine = "1.6.4"
@@ -18,11 +17,13 @@ lifecycle-common-java8 = { module = "androidx.lifecycle:lifecycle-common-java8",
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutine" }
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutine" }
 
-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
+compose-bom = "androidx.compose:compose-bom:2023.01.00"
+compose-ui = { module = "androidx.compose.ui:ui" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+compose-foundation = { module = "androidx.compose.foundation:foundation" }
+compose-material = { module = "androidx.compose.material:material" }
+compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4" }
 
 activity-compose = "androidx.activity:activity-compose:1.6.1"
 navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation" }
@@ -39,7 +40,6 @@ kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-metadata = { module = "com.squareup:kotlinpoet-metadata", version.ref = "kotlinpoet" }
 
 
-#androidTestImplementation("androidx.compose.ui:ui-test-junit4:${Versions.composeVersion}")
 #androidTestImplementation("junit:junit:4.13.2")
 #androidTestImplementation("androidx.test:rules:1.4.0")
 #androidTestImplementation("androidx.test:runner:1.4.0")
@@ -51,7 +51,6 @@ kotlinpoet-metadata = { module = "com.squareup:kotlinpoet-metadata", version.ref
 
 [bundles]
 lifecycle = ["lifecycle-viewmodel", "lifecycle-common-java8"]
-compose = ["compose-ui", "compose-ui-tooling", "compose-foundation", "compose-material", "compose-material-icons-extended"]
 coroutines = ["kotlin-coroutines-core", "kotlin-coroutines-android"]
 
 [plugins]

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -54,11 +54,13 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.lifecycle.viewmodel)
 
+    implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)
     implementation(libs.compose.foundation)
     api(libs.navigation.compose)
 
-    androidTestImplementation("androidx.compose.ui:ui-test:${Versions.composeVersion}")
+    androidTestImplementation(platform(libs.compose.bom))
+    androidTestImplementation(libs.compose.ui.test)
     androidTestImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.test:runner:1.5.2")

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -50,8 +50,9 @@ dependencies {
     implementation(project(":library"))
     kapt(project(":compiler"))
 
+    implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)
-    implementation(libs.compose.ui.tooling)
     implementation(libs.compose.foundation)
     implementation(libs.navigation.compose)
+    debugImplementation(libs.compose.ui.tooling)
 }


### PR DESCRIPTION
## Overview
- Resolved a build error depending on a non-existent version of Compose.
  - So, change to a dependency in the BOM that does not change the version after the change.
- Fixed the project dependency on ui-tooling so that it depends only when debug build.