### PR TITLE
register route classes in ScreenFactoryRegistry to look them up correctly

### DIFF
--- a/compiler/src/main/kotlin/model/ComposeDestinationBuilder.kt
+++ b/compiler/src/main/kotlin/model/ComposeDestinationBuilder.kt
@@ -69,7 +69,7 @@ data class ComposeDestinationBuilder(
                 ScreenFactoryRegistry,
                 ScreenFactoryRegistry.member("register"),
                 screenRoute.route,
-                baseClassName,
+                routeClassName,
                 routeClassName,
             )
         }


### PR DESCRIPTION
Looks like `SavedStateHandle.screen()` cannot find its associated `Screen` and throws an exception.
I believe `ComposeDestinationBuilder` wants to register the concrete type of routes in `ScreenFactoryRegistry` to look them up afterwards though, it apparently takes the base type of them instead.


## Steps to reproduce

1. Run the sample app in the project.
2. It exits unexpectedly in a second.


## Log

Here's a snippet of the exception thrown in the sample app:

```
FATAL EXCEPTION: main                                                                         
Process: jp.takuji31.compose.navigation.example, PID: 14202                                                                                     
java.lang.IllegalStateException: Screen factory for class[Home] not registered.
    at jp.takuji31.compose.navigation.screen.ScreenFactoryRegistry.findByClass(ScreenFactoryRegistry.kt:23)
    at jp.takuji31.compose.navigation.screen.SavedStateHandleScreenPropertyDelegate.getValue(SavedStateHandle.kt:20)
    at jp.takuji31.compose.navigation.example.ui.HomeViewModel.getScreen(HomeViewModel.kt:22)
```
