### PR TITLE
Fixed app module failing to build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,12 +15,14 @@ tasks.create<Delete>("clean") {
     delete(rootProject.buildDir)
 }
 
-/**
- * https://github.com/google/ksp/issues/1288
- */
-tasks.withType<KotlinCompile>()
-    .configureEach {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_11.toString()
+subprojects {
+    /**
+     * https://github.com/google/ksp/issues/1288
+     */
+    tasks.withType<KotlinCompile>()
+        .configureEach {
+            kotlinOptions {
+                jvmTarget = JavaVersion.VERSION_11.toString()
+            }
         }
-    }
+}


### PR DESCRIPTION
## Overview
- Fixed the app module build failing with the following error.  
```
> Task :common:compileKotlin FAILED
Execution failed for task ':common:compileKotlin'.
> 'compileJava' task (current target is 11) and 'compileKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
  Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```