### PR TITLE
Fixed startDestination route

### DIFF
--- a/library/src/main/kotlin/ScreenNavHost.kt
+++ b/library/src/main/kotlin/ScreenNavHost.kt
@@ -14,7 +14,7 @@ fun ScreenNavHost(
 ) {
     NavHost(
         navController = navController.navController,
-        startDestination = startScreen.parameterizedRoute,
+        startDestination = startScreen.route,
         builder = builder,
         modifier = modifier,
     )


### PR DESCRIPTION
## Overview
- Fixed an issue where `findStartDestination` could not find a screen with parameters when it was set to `startDestination`.