### PR TITLE
Use JDK17 at JitPack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-    - openjdk11
+    - openjdk17


### PR DESCRIPTION
## Overview
- AGP 8.0 or later requires JDK 17.
- JitPack was still using JDK11, so I changed it to use JDK17.