### PR TITLE
Change the name of popupTo because the function implemented in navigation-compose 1.8.0 has been changed to be called.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fun Main(navController: ScreenNavController) { // val navController = rememberSc
     ) {
         val onBottomSheetItemClicked: (ExampleScreen) -> Unit = { screen ->
             navController.navigate(screen) {
-                popUpTo(ExampleScreenId.Home) { inclusive = screen == ExampleScreen.Home }
+                popUpToScreenId(ExampleScreenId.Home) { inclusive = screen == ExampleScreen.Home }
             }
         }
         exampleScreenComposable {

--- a/app/src/main/kotlin/ui/Main.kt
+++ b/app/src/main/kotlin/ui/Main.kt
@@ -8,7 +8,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import jp.takuji31.compose.navigation.example.navigation.ExampleScreen
 import jp.takuji31.compose.navigation.example.navigation.ExampleScreenId
 import jp.takuji31.compose.navigation.example.navigation.exampleScreenComposable
-import jp.takuji31.compose.navigation.example.navigation.popUpTo
+import jp.takuji31.compose.navigation.example.navigation.popUpToScreenId
 import jp.takuji31.compose.navigation.screen.ScreenNavController
 import jp.takuji31.compose.navigation.screen.ScreenNavHost
 
@@ -22,7 +22,7 @@ fun Main(navController: ScreenNavController) {
     ) {
         val onBottomSheetItemClicked: (ExampleScreen) -> Unit = { screen ->
             navController.navigate(screen) {
-                popUpTo(ExampleScreenId.Home) { inclusive = screen is ExampleScreen.Home }
+                popUpToScreenId(ExampleScreenId.Home) { inclusive = screen is ExampleScreen.Home }
             }
         }
         exampleScreenComposable(deepLinkPrefix = "compose-navigation-example://blog.takuji31.jp") {

--- a/compiler/src/main/kotlin/visitor/NavOptionsBuilderFunctionVisitor.kt
+++ b/compiler/src/main/kotlin/visitor/NavOptionsBuilderFunctionVisitor.kt
@@ -3,6 +3,8 @@ package jp.takuji31.compose.navigation.compiler.visitor
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSDefaultVisitor
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.LambdaTypeName
@@ -18,18 +20,31 @@ class NavOptionsBuilderFunctionVisitor : KSDefaultVisitor<FileSpec.Builder, Unit
         data: FileSpec.Builder,
     ) {
         val idClass = classDeclaration.toClassName()
+        val spec = FunSpec.builder("popUpToScreenId")
+            .addPopupToBody(idClass)
 
-        val spec = FunSpec.builder("popUpTo")
-            .receiver(NavOptionsBuilder)
-            .addParameter("id", idClass)
-            .addParameter("builder", LambdaTypeName.get(PopUpToBuilder, returnType = UNIT))
-            .addStatement(
-                "return popUpTo(id.%M, builder)",
-                MemberName(idClass.packageName, "route"),
+        val deprecatedSpec = FunSpec.builder("popUpTo")
+            .addPopupToBody(idClass)
+            .addAnnotation(
+                AnnotationSpec.builder(Deprecated::class)
+                    .addMember("message = \"The function implemented in navigation-compose 1.8.0 is being called\"")
+                    .addMember("replaceWith = ReplaceWith(\"popUpToScreenId(id, builder)\")")
+                    .addMember("level = DeprecationLevel.ERROR")
+                    .build()
             )
 
         data.addFunction(spec.build())
+        data.addFunction(deprecatedSpec.build())
     }
+
+    private fun FunSpec.Builder.addPopupToBody(idClass: ClassName) = this
+        .receiver(NavOptionsBuilder)
+        .addParameter("id", idClass)
+        .addParameter("builder", LambdaTypeName.get(PopUpToBuilder, returnType = UNIT))
+        .addStatement(
+            "return popUpTo(id.%M, builder)",
+            MemberName(idClass.packageName, "route"),
+        )
 
     override fun defaultHandler(node: KSNode, data: FileSpec.Builder) {}
 }


### PR DESCRIPTION
The following functions have been implemented in navigation-compose:2.8.0 NavOptionsBuilder.
https://developer.android.com/jetpack/androidx/releases/navigation#version_28_2

```kotlin
// align with other popUpTo overloads where this is suppressed in baseline lint ignore
@Suppress("BuilderSetStyle", "MissingJvmstatic")
public actual fun <T : Any> popUpTo(route: T, popUpToBuilder: PopUpToBuilder.() -> Unit) {
    popUpToRouteObject = route
    popUpToId = -1
    popUpToRoute = null
    val builder = PopUpToBuilder().apply(popUpToBuilder)
    inclusive = builder.inclusive
    saveState = builder.saveState
}
```

Change the name because navigation-compose function will be called.